### PR TITLE
Take out abnormal unicode characters by normalizing the data

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -126,7 +126,7 @@ class WhatsAppParser(Parser):
             messages_raw = reversed(list(f))
 
         for line in messages_raw:
-            line = unicodedata.normalize('NFKC',line.strip())
+            line = unicodedata.normalize("NFKC", line.strip())
 
             if not line:
                 continue

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -1,3 +1,4 @@
+import unicodedata
 import json
 import logging
 import re
@@ -125,7 +126,7 @@ class WhatsAppParser(Parser):
             messages_raw = reversed(list(f))
 
         for line in messages_raw:
-            line = line.strip()
+            line = unicodedata.normalize('NFKC',line.strip())
 
             if not line:
                 continue

--- a/test/whatsapp/target.json
+++ b/test/whatsapp/target.json
@@ -1,3 +1,4 @@
+{"datetime":1662849420000,"author":"John Doe","message":"Testing abnormal unicode","weekday":"Saturday","hour":22,"words":3,"letters":24}
 {"datetime":1662849420000,"author":"John Doe","message":"Testing date dashes","weekday":"Saturday","hour":22,"words":3,"letters":19}
 {"datetime":1662849420000,"author":"John Doe","message":"Testing brackets","weekday":"Saturday","hour":22,"words":2,"letters":16}
 {"datetime":1662849420000,"author":"John Doe","message":"Testing date and time formats","weekday":"Saturday","hour":22,"words":5,"letters":29}

--- a/test/whatsapp/testlog.txt
+++ b/test/whatsapp/testlog.txt
@@ -18,3 +18,4 @@ Cras scelerisque neque.
 09/10/22 10:37:00 p.m. - John Doe: Testing date and time formats
 [09/10/22 10:37:00 p.m.] John Doe: Testing brackets
 09-10-2022 10:37:00 p.m. - John Doe: Testing date dashes
+09/10/22, 10:37 p. m. - John Doe: Testing abnormal unicode


### PR DESCRIPTION
While processing an exported Whatsapp chat, I came across with Unicode not relevant to the message, such as:
```
hello\xa0world
```
This PR normalizes the data and removes Unicode that is not useful whatsoever