### PR TITLE
[Issue-33] Add whatsapp test line to cover emojis in the author

### DIFF
--- a/test/whatsapp/target.json
+++ b/test/whatsapp/target.json
@@ -1,3 +1,5 @@
+{"datetime":1662849420000,"author":"🤓","message":"Testing emoji 🤓","weekday":"Saturday","hour":22,"words":3,"letters":15}
+{"datetime":1662849420000,"author":"John Doe 🤓","message":"Testing emoji 🤓","weekday":"Saturday","hour":22,"words":3,"letters":15}
 {"datetime":1662849420000,"author":"John Doe","message":"Testing abnormal unicode","weekday":"Saturday","hour":22,"words":3,"letters":24}
 {"datetime":1635088903000,"author":"John-John Doe","message":"Testing dash - in message body","weekday":"Sunday","hour":15,"words":6,"letters":30}
 {"datetime":1635088903000,"author":"John-John Doe","message":"Testing dash in author's first name","weekday":"Sunday","hour":15,"words":6,"letters":35}

--- a/test/whatsapp/testlog.txt
+++ b/test/whatsapp/testlog.txt
@@ -22,3 +22,5 @@ Cras scelerisque neque.
 10.24.21, 15:21:43 - John-John Doe: Testing dash in author's first name
 [10.24.21, 15:21:43] John-John Doe: Testing dash - in message body
 09/10/22, 10:37 p. m. - John Doe: Testing abnormal unicode
+09/10/22, 10:37 p. m. - John Doe 🤓: Testing emoji 🤓
+09/10/22, 10:37 p. m. - 🤓: Testing emoji 🤓


### PR DESCRIPTION
This PR adds tests to cover emojis in the author for Issue https://github.com/joweich/chat-miner/issues/33. Previous to PR https://github.com/joweich/chat-miner/pull/35, emojis were not being processed correctly as part of the author, thus logging the author as System.
With the changes made in PR https://github.com/joweich/chat-miner/pull/35, the problem is solved since regular expressions are no longer used to obtain the author, and obtaining what is between `timestamp_author_sep` and `:` solves the issue.