### PR TITLE
Introduced calendar heatmap visualizing message frequency on a daily basis

### DIFF
--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -7,6 +7,7 @@ from wordcloud import WordCloud, STOPWORDS
 from dateutil.relativedelta import relativedelta
 from matplotlib.patches import Polygon
 from matplotlib.colors import ColorConverter, ListedColormap
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 
 def sunburst(df: pd.DataFrame):
@@ -167,7 +168,11 @@ def calendar_heatmap(
 
     kwargs["linewidth"] = linewidth
     kwargs["edgecolors"] = linecolor
-    ax.pcolormesh(plot_data, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
+    pc = ax.pcolormesh(plot_data, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
+
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size="3%", pad=0.08)
+    plt.colorbar(pc, cax=cax, ticks=[min(vmin), (min(vmin) + max(vmax)) / 2, max(vmax)])
 
     ax.set(xlim=(0, plot_data.shape[1]), ylim=(0, plot_data.shape[0]))
 
@@ -230,10 +235,9 @@ def calendar_heatmap(
     ax.set_xticks(xticks)
     ax.set_xticklabels(labels)
     ax.set_ylabel("")
-    ax.yaxis.set_ticks_position("right")
+    ax.yaxis.set_ticks_position("left")
     ax.set_yticks([6 - i + 0.5 for i in dayticks])
     ax.set_yticklabels(
         [daylabels[i] for i in dayticks], rotation="horizontal", va="center"
     )
-
     return ax

--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -157,10 +157,10 @@ def calendar_heatmap(
     df.loc[(df.index.month == 1) & (df.week > 50), "week"] = 0
     df.loc[(df.index.month == 12) & (df.week < 10), "week"] = df.week.max() + 1
 
-    plot_data = df.pivot("day", "week", "message").values[::-1]
+    plot_data = df.pivot(index="day", columns="week", values="message").values[::-1]
     plot_data = np.ma.masked_where(np.isnan(plot_data), plot_data)
 
-    fill_data = df.pivot("day", "week", "fill").values[::-1]
+    fill_data = df.pivot(index="day", columns="week", values="message").values[::-1]
     fill_data = np.ma.masked_where(np.isnan(fill_data), fill_data)
 
     ax.pcolormesh(fill_data, vmin=0, vmax=1, cmap=ListedColormap([fillcolor]))


### PR DESCRIPTION
**Inspired by GitHub's contribution chart and adapted matplotlib-based code from [the calmap](https://github.com/MarvinT/calmap/) repo**

Main additions to the calmap repo include:
- Compatibility to dataframe output of chatparsers
- Colorbar