### PR TITLE
Add test support for facebookMessenger chats

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,10 @@
+# Testing considerations
+
+## How to run pytest
+```
+python3 -m pytest
+```
+## Test parsers
+### Facebook Messenger
+
+When adding a new test object in test/facebookMessenger/target.json, make sure that the ```hour``` attribute is in UTC-0. When running pytest, ```hour``` and ```timedate``` will be converted to the users timezone to avoid timezone errors.

--- a/test/facebookMessenger/target.json
+++ b/test/facebookMessenger/target.json
@@ -1,0 +1,4 @@
+[
+    {"datetime":1668628203612,"author":"John Doe","message":"Hello Allan","weekday":"Wednesday","hour":19,"words":2,"letters":11},
+    {"datetime":1668628203612,"author":"Allan Smith","message":"Hello John","weekday":"Wednesday","hour":19,"words":2,"letters":10}
+]

--- a/test/facebookMessenger/testlog.json
+++ b/test/facebookMessenger/testlog.json
@@ -1,0 +1,16 @@
+{
+    "messages": [
+        {
+            "sender_name": "Allan Smith",
+            "timestamp_ms": 1668628203612,
+            "content": "Hello John",
+            "type": "Generic"
+        },
+        {
+            "sender_name": "John Doe",
+            "timestamp_ms": 1668628203612,
+            "content": "Hello Allan",
+            "type": "Generic"
+        }
+    ]
+}

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -1,5 +1,6 @@
 import pandas as pd
-from chatminer.chatparsers import WhatsAppParser
+from chatminer.chatparsers import WhatsAppParser, FacebookMessengerParser
+import datetime
 
 
 def test_whatsapp():
@@ -9,4 +10,40 @@ def test_whatsapp():
     for (_, row_res), (_, row_target) in zip(parser.df.iterrows(), df_test.iterrows()):
         assert row_res.equals(row_target), row_res.compare(
             row_target, result_names=("result", "target")
+        )
+
+
+def test_facebookMessenger():
+    parser = FacebookMessengerParser("test/facebookMessenger/testlog.json")
+    parser.parse_file_into_df()
+    # set convert_dates to false since if set to true, the conversion will use UTC 0 instead of using the users local timezone
+    df_test = pd.read_json(
+        "test/facebookMessenger/target.json", orient="records", convert_dates=False
+    )
+    adjustUtcTimestamp(df_test)
+    for (_, row_res), (_, row_target) in zip(parser.df.iterrows(), df_test.iterrows()):
+        assert row_res.equals(row_target), row_res.compare(
+            row_target, result_names=("result", "target")
+        )
+
+
+def adjustUtcTimestamp(df: pd.DataFrame):
+    for index in df.index:
+        # Convert timestamp to datetime format with the local timezone
+        df.at[index, "datetime"] = datetime.datetime.fromtimestamp(
+            df.at[index, "datetime"] / 1000
+        )
+        # Adjust the hour by the UTC hour difference. i.e. If hour is 15 and the timezone is UTC-6, then hour will be 9
+        df.at[index, "hour"] = df.at[index, "hour"] + (
+            round(
+                (
+                    round(
+                        (
+                            datetime.datetime.now() - datetime.datetime.utcnow()
+                        ).total_seconds()
+                    )
+                    / 1800
+                )
+                / 2
+            )
         )


### PR DESCRIPTION
* Added test parser for Facebook messenger chats
**Note**
 When adding a new test object in test/facebookMessenger/target.json, make sure that the ```hour``` attribute is in UTC-0. When running pytest, ```hour``` and ```timedate``` will be converted to the users timezone to avoid timezone errors.