### PR TITLE
Fixed incorrect parsing for WhatsApp messages starting with unicode left-to-right character (U-200E)

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -119,7 +119,7 @@ class WhatsAppParser(Parser):
 
     def _read_file_into_list(self):
         def _is_new_message(line):
-            regex = r"(^\[?((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{4})|(\d{2})))"
+            regex = r"(^[\u200e]?\[?((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{4})|(\d{2})))"
             return re.match(regex, line)
 
         self._logger.info("Starting reading raw messages into memory...")
@@ -129,16 +129,17 @@ class WhatsAppParser(Parser):
             messages_raw = reversed(list(f))
 
         for line in messages_raw:
-            line = unicodedata.normalize("NFKC", line.strip())
-
             if not line:
                 continue
 
             if _is_new_message(line):
+                line = line.replace("\u200e", "")
+                line = unicodedata.normalize("NFKC", line.strip())
                 if buffer:
                     buffer.append(line)
                     buffer.reverse()
-                    self.messages.append(" ".join(buffer))
+                    joined_buffer = " ".join(buffer)
+                    self.messages.append("".join(joined_buffer.splitlines()))
                     buffer.clear()
                 else:
                     self.messages.append(line)


### PR DESCRIPTION
For some reason, lines containing media files start with the unicode left-to-right character in chat exports for WhatsApp. Before this fix, those lines where simply appended to the previous messages. This also caused the wordcloud viz to show the authors names prominently.
This fix detects U-200E characters, strips them and reconstructs the message accordingly.