### PR TITLE
TelegramJsonParser now allows for chat selection

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -256,7 +256,9 @@ class TelegramJsonParser(Parser):
                 "Finished reading %i raw messages into memory.", len(self.messages)
             )
         else:
-            self._logger.error(f"Chat \"{self.chat_name}\" was not found within provided Telegram data.")
+            self._logger.error(
+                f'Chat "{self.chat_name}" was not found within provided Telegram data.'
+            )
             raise ValueError
 
     def _parse_message(self, mess):


### PR DESCRIPTION
- search for correct chat is linear, ~O(N), as number of chat will unlikely be unbearable (?)
- two separate \_\_init\_\_ arguments are used (both optional because...backward compatibility?), since saved_messages chat doesn't have the "name" key (maybe better to infer saved messages by leaving chat_name empty, and get rid of saved_messages flag?)
- use saved_messages boolean flag to parse saved messages
- use chat_name to choose the chat to parse

(PyCharm auto formatter touched imports, but they seem to be fine)