### PR TITLE
Added functionality to process yyyy/MM/dd date format

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -61,7 +61,8 @@ class Parser(ABC):
     def _add_metadata(self):
         self.df["weekday"] = self.df["datetime"].dt.day_name()
         self.df["hour"] = self.df["datetime"].dt.hour
-        self.df["words"] = self.df["message"].apply(lambda s: len(s.split(" ")))
+        self.df["words"] = self.df["message"].apply(
+            lambda s: len(s.split(" ")))
         self.df["letters"] = self.df["message"].apply(len)
 
     @abstractmethod
@@ -154,15 +155,23 @@ class WhatsAppParser(Parser):
     def _infer_datetime_format(self):
         max_first = 0
         max_second = 0
-        dayIndex = 0
         for line in self.messages:
-            line = line.replace(r"/", ".", 2).replace("-", ".", 2).replace(",", ".", 2).lstrip("[")
+            line = (
+               line.replace(r"/", ".", 2)
+                .replace("-", ".", 2)
+                .replace(",", ".", 2)
+                .lstrip("[")
+            )
             yearcheck = line.split(".")[:1]
             if len(str(yearcheck[0])) > 2:
-                dayIndex = 2
-            day_and_month = [int(num) for num in line.split(".")[:3]]
-            max_first = max(max_first, day_and_month[dayIndex])
-            max_second = max(max_second, day_and_month[1])
+                day_and_month = [int(num) for num in line.split(".")[:3]]
+                max_first = max(max_first, day_and_month[1])
+                max_second = max(max_second, day_and_month[2])
+            else:
+                day_and_month = [int(num) for num in line.split(".")[:2]]
+                max_first = max(max_first, day_and_month[0])
+                max_second = max(max_second, day_and_month[1])
+                
             if (max_first > 12) and (max_second > 12):
                 raise ValueError(f"Invalid date format: {line}")
 

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -61,8 +61,7 @@ class Parser(ABC):
     def _add_metadata(self):
         self.df["weekday"] = self.df["datetime"].dt.day_name()
         self.df["hour"] = self.df["datetime"].dt.hour
-        self.df["words"] = self.df["message"].apply(
-            lambda s: len(s.split(" ")))
+        self.df["words"] = self.df["message"].apply(lambda s: len(s.split(" ")))
         self.df["letters"] = self.df["message"].apply(len)
 
     @abstractmethod
@@ -157,7 +156,7 @@ class WhatsAppParser(Parser):
         max_second = 0
         for line in self.messages:
             line = (
-               line.replace(r"/", ".", 2)
+                line.replace(r"/", ".", 2)
                 .replace("-", ".", 2)
                 .replace(",", ".", 2)
                 .lstrip("[")
@@ -171,7 +170,7 @@ class WhatsAppParser(Parser):
                 day_and_month = [int(num) for num in line.split(".")[:2]]
                 max_first = max(max_first, day_and_month[0])
                 max_second = max(max_second, day_and_month[1])
-                
+
             if (max_first > 12) and (max_second > 12):
                 raise ValueError(f"Invalid date format: {line}")
 

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -161,15 +161,14 @@ class WhatsAppParser(Parser):
                 .replace(",", ".", 2)
                 .lstrip("[")
             )
-            yearcheck = line.split(".")[:1]
-            if len(str(yearcheck[0])) > 2:
-                day_and_month = [int(num) for num in line.split(".")[:3]]
-                max_first = max(max_first, day_and_month[1])
-                max_second = max(max_second, day_and_month[2])
+            check_year_first = int(line.split(".")[0]) >= 100
+            if check_year_first:
+                day_and_month = [int(num) for num in line.split(".")[1:3]]
             else:
                 day_and_month = [int(num) for num in line.split(".")[:2]]
-                max_first = max(max_first, day_and_month[0])
-                max_second = max(max_second, day_and_month[1])
+
+            max_first = max(max_first, day_and_month[0])
+            max_second = max(max_second, day_and_month[1])
 
             if (max_first > 12) and (max_second > 12):
                 raise ValueError(f"Invalid date format: {line}")

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -154,13 +154,12 @@ class WhatsAppParser(Parser):
     def _infer_datetime_format(self):
         max_first = 0
         max_second = 0
+        dayIndex = 0
         for line in self.messages:
             line = line.replace(r"/", ".", 2).replace("-", ".", 2).replace(",", ".", 2).lstrip("[")
             yearcheck = line.split(".")[:1]
             if len(str(yearcheck[0])) > 2:
                 dayIndex = 2
-            else:
-                dayIndex = 0
             day_and_month = [int(num) for num in line.split(".")[:3]]
             max_first = max(max_first, day_and_month[dayIndex])
             max_second = max(max_second, day_and_month[1])

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -120,7 +120,7 @@ class WhatsAppParser(Parser):
 
     def _read_file_into_list(self):
         def _is_new_message(line):
-            regex = r"(^[\u200e]?\[?((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{4})|(\d{2})))"
+            regex = r"(^[\u200e]?\[?((\d{1})|(\d{2})|(\d{4}))((\.)|(\/)|(\-))((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{4})|(\d{2})))"
             return re.match(regex, line)
 
         self._logger.info("Starting reading raw messages into memory...")
@@ -155,9 +155,14 @@ class WhatsAppParser(Parser):
         max_first = 0
         max_second = 0
         for line in self.messages:
-            line = line.replace(r"/", ".", 2).replace("-", ".", 2).lstrip("[")
-            day_and_month = [int(num) for num in line.split(".")[:2]]
-            max_first = max(max_first, day_and_month[0])
+            line = line.replace(r"/", ".", 2).replace("-", ".", 2).replace(",", ".", 2).lstrip("[")
+            yearcheck = line.split(".")[:1]
+            if len(str(yearcheck[0])) > 2:
+                dayIndex = 2
+            else:
+                dayIndex = 0
+            day_and_month = [int(num) for num in line.split(".")[:3]]
+            max_first = max(max_first, day_and_month[dayIndex])
             max_second = max(max_second, day_and_month[1])
             if (max_first > 12) and (max_second > 12):
                 raise ValueError(f"Invalid date format: {line}")

--- a/test/whatsapp/target.json
+++ b/test/whatsapp/target.json
@@ -1,3 +1,6 @@
+{"datetime":1671886860000,"author":"🤓","message":"Testing emoji 🤓 with yyyy first","weekday":"Saturday","hour":13,"words":6,"letters":31}
+{"datetime":1671886860000,"author":"John Doe 🤓","message":"Testing emoji 🤓 with yyyy first","weekday":"Saturday","hour":13,"words":6,"letters":31}
+{"datetime":1671886860000,"author":"John Doe","message":"Testing abnormal unicode with yyyy first","weekday":"Saturday","hour":13,"words":6,"letters":40}
 {"datetime":1662849420000,"author":"🤓","message":"Testing emoji 🤓","weekday":"Saturday","hour":22,"words":3,"letters":15}
 {"datetime":1662849420000,"author":"John Doe 🤓","message":"Testing emoji 🤓","weekday":"Saturday","hour":22,"words":3,"letters":15}
 {"datetime":1662849420000,"author":"John Doe","message":"Testing abnormal unicode","weekday":"Saturday","hour":22,"words":3,"letters":24}

--- a/test/whatsapp/testlog.txt
+++ b/test/whatsapp/testlog.txt
@@ -24,3 +24,6 @@ Cras scelerisque neque.
 09/10/22, 10:37 p. m. - John Doe: Testing abnormal unicode
 09/10/22, 10:37 p. m. - John Doe 🤓: Testing emoji 🤓
 09/10/22, 10:37 p. m. - 🤓: Testing emoji 🤓
+2018/12/24, 13:01. - John Doe: Testing abnormal unicode with yyyy first
+2018/12/24, 13:01. - John Doe 🤓: Testing emoji 🤓 with yyyy first
+2018/12/24, 13:01. - 🤓: Testing emoji 🤓 with yyyy first

--- a/test/whatsapp/testlog.txt
+++ b/test/whatsapp/testlog.txt
@@ -24,6 +24,6 @@ Cras scelerisque neque.
 09/10/22, 10:37 p. m. - John Doe: Testing abnormal unicode
 09/10/22, 10:37 p. m. - John Doe 🤓: Testing emoji 🤓
 09/10/22, 10:37 p. m. - 🤓: Testing emoji 🤓
-2018/12/24, 13:01. - John Doe: Testing abnormal unicode with yyyy first
-2018/12/24, 13:01. - John Doe 🤓: Testing emoji 🤓 with yyyy first
-2018/12/24, 13:01. - 🤓: Testing emoji 🤓 with yyyy first
+2022/12/24, 13:01. - John Doe: Testing abnormal unicode with yyyy first
+2022/12/24, 13:01. - John Doe 🤓: Testing emoji 🤓 with yyyy first
+2022/12/24, 13:01. - 🤓: Testing emoji 🤓 with yyyy first


### PR DESCRIPTION
A couple of my friends had their exports come out in yyyy/mm/dd format and the current system could not process that.

Thus, I made a change to the Regex to also check for yyyy in the first column.

Then if the first column is actually a year, then select the day from the 3rd column