### PR TITLE
Catching messages without type field for facebook JSON export

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -230,7 +230,7 @@ class FacebookMessengerParser(Parser):
             else:
                 body = mess["content"]
         else:
-            self._logger.warning("Skipped message without type-field: %s", {mess})
+            self._logger.warning("Skipped message without type-field: %s", mess)
             return None
 
         parsed_message = {

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -222,12 +222,16 @@ class FacebookMessengerParser(Parser):
         )
 
     def _parse_message(self, mess):
-        if mess["type"] == "Share":
-            body = mess["share"]["link"]
-        elif "sticker" in mess:
-            body = mess["sticker"]["uri"]
+        if "type" in mess:
+            if mess["type"] == "Share":
+                body = mess["share"]["link"]
+            elif "sticker" in mess:
+                body = mess["sticker"]["uri"]
+            else:
+                body = mess["content"]
         else:
-            body = mess["content"]
+            self._logger.warning("Skipped message without type-field: %s", {mess})
+            return None
 
         parsed_message = {
             "datetime": datetime.datetime.fromtimestamp(mess["timestamp_ms"] / 1000),

--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -222,15 +222,14 @@ class FacebookMessengerParser(Parser):
         )
 
     def _parse_message(self, mess):
-        if "type" in mess:
-            if mess["type"] == "Share":
-                body = mess["share"]["link"]
-            elif "sticker" in mess:
-                body = mess["sticker"]["uri"]
-            else:
-                body = mess["content"]
+        if "type" in mess and mess["type"] == "Share":
+            body = mess["share"]["link"]
+        elif "sticker" in mess:
+            body = mess["sticker"]["uri"]
+        elif "content" in mess:
+            body = mess["content"]
         else:
-            self._logger.warning("Skipped message without type-field: %s", mess)
+            self._logger.warning("Skipped message with unknown format: %s", mess)
             return None
 
         parsed_message = {


### PR DESCRIPTION
Raised in #52 and #56, it seems like some of the fields in the JSON export of facebook don't hold a `type`, which we currently use to identify which content to retrieve from the nested JSON. This PR is meant to identify the messages without type field and fix #56. 
This PR's initial commit introduces:

- Ignoring messages without `type` field
- Printing those messages to the command line