### PR TITLE
Introduce radarchart visualizing message count per weekday

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/chat-miner.svg)](https://pypi.org/project/chat-miner/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Downloads](https://static.pepy.tech/badge/chat-miner)](https://pepy.tech/project/chat-miner)
 
 **chat-miner** provides lean parsers for every major platform transforming chats into pandas dataframes. Artistic visualizations allow you to explore your data differently and create artwork from your chats.
 
@@ -68,4 +69,14 @@ ax = vis.wordcloud(parser.df, ax=ax, stopwords=stopwords, **kwargs)
 ```
 <p align="center">
   <img src="examples/wordcloud.svg">
+</p>
+
+### 4.4 Radarchart: Message count per weekday
+```python
+fig, ax = plt.subplots(1, 2, figsize=(7, 3), subplot_kw={'projection': 'radar'})
+ax[0] = vis.radar(parser.df, ax=ax[0])
+ax[1] = vis.radar(parser.df, ax=ax[1], color='C1', alpha=0)
+```
+<p align="center">
+  <img src="examples/radar.svg">
 </p>

--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -3,11 +3,18 @@ import datetime
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from pandas.api.types import CategoricalDtype
 from wordcloud import WordCloud, STOPWORDS
 from dateutil.relativedelta import relativedelta
 from matplotlib.patches import Polygon
 from matplotlib.colors import ColorConverter, ListedColormap
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from matplotlib.patches import Circle, RegularPolygon
+from matplotlib.path import Path
+from matplotlib.projections.polar import PolarAxes
+from matplotlib.projections import register_projection
+from matplotlib.spines import Spine
+from matplotlib.transforms import Affine2D
 
 
 def sunburst(
@@ -254,3 +261,116 @@ def calendar_heatmap(
     )
     plt.tight_layout()
     return ax
+
+
+def radar(
+    df,
+    color="C0",
+    alpha=0.3,
+    ax=None,
+    authors=[],
+):
+    if authors:
+        df = df[df["author"].isin(authors)]
+
+    cats = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+    df_radar = df.groupby(by="weekday")["message"].count().reindex(cats)
+
+    theta = radar_factory(7, frame="polygon")
+
+    if ax is None:
+        _, ax = plt.subplots(subplot_kw={"projection": "radar"})
+
+    ax.plot(theta, df_radar.values, color=color)
+    ax.fill(theta, df_radar.values, facecolor=color, alpha=alpha)
+    ax.set_varlabels(cats)
+    return ax
+
+
+def radar_factory(num_vars, frame="circle"):
+    """
+    Source: https://matplotlib.org/stable/gallery/specialty_plots/radar_chart.html
+    """
+    # calculate evenly-spaced axis angles
+    theta = np.linspace(0, 2 * np.pi, num_vars, endpoint=False)
+
+    class RadarTransform(PolarAxes.PolarTransform):
+        def transform_path_non_affine(self, path):
+            # Paths with non-unit interpolation steps correspond to gridlines,
+            # in which case we force interpolation (to defeat PolarTransform's
+            # autoconversion to circular arcs).
+            if path._interpolation_steps > 1:
+                path = path.interpolated(num_vars)
+            return Path(self.transform(path.vertices), path.codes)
+
+    class RadarAxes(PolarAxes):
+
+        name = "radar"
+        PolarTransform = RadarTransform
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # rotate plot such that the first axis is at the top
+            self.set_theta_zero_location("N")
+
+        def fill(self, *args, closed=True, **kwargs):
+            """Override fill so that line is closed by default"""
+            return super().fill(closed=closed, *args, **kwargs)
+
+        def plot(self, *args, **kwargs):
+            """Override plot so that line is closed by default"""
+            lines = super().plot(*args, **kwargs)
+            for line in lines:
+                self._close_line(line)
+
+        def _close_line(self, line):
+            x, y = line.get_data()
+            # FIXME: markers at x[0], y[0] get doubled-up
+            if x[0] != x[-1]:
+                x = np.append(x, x[0])
+                y = np.append(y, y[0])
+                line.set_data(x, y)
+
+        def set_varlabels(self, labels):
+            self.set_thetagrids(np.degrees(theta), labels)
+
+        def _gen_axes_patch(self):
+            # The Axes patch must be centered at (0.5, 0.5) and of radius 0.5
+            # in axes coordinates.
+            if frame == "circle":
+                return Circle((0.5, 0.5), 0.5)
+            elif frame == "polygon":
+                return RegularPolygon((0.5, 0.5), num_vars, radius=0.5, edgecolor="k")
+            else:
+                raise ValueError("Unknown value for 'frame': %s" % frame)
+
+        def _gen_axes_spines(self):
+            if frame == "circle":
+                return super()._gen_axes_spines()
+            elif frame == "polygon":
+                # spine_type must be 'left'/'right'/'top'/'bottom'/'circle'.
+                spine = Spine(
+                    axes=self,
+                    spine_type="circle",
+                    path=Path.unit_regular_polygon(num_vars),
+                )
+                # unit_regular_polygon gives a polygon of radius 1 centered at
+                # (0, 0) but we want a polygon of radius 0.5 centered at (0.5,
+                # 0.5) in axes coordinates.
+                spine.set_transform(
+                    Affine2D().scale(0.5).translate(0.5, 0.5) + self.transAxes
+                )
+                return {"polar": spine}
+            else:
+                raise ValueError("Unknown value for 'frame': %s" % frame)
+
+    register_projection(RadarAxes)
+    return theta

--- a/examples/radar.svg
+++ b/examples/radar.svg
@@ -1,0 +1,1248 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="504pt" height="216pt" viewBox="0 0 504 216" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2023-01-07T01:00:02.322039</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 216 
+L 504 216 
+L 504 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 131.8725 29.84 
+L 67.003213 61.079402 
+L 50.981822 131.273702 
+L 95.872762 187.565159 
+L 167.872238 187.565159 
+L 212.763178 131.273702 
+L 196.741787 61.079402 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 131.8725 88.330573 
+L 107.655154 93.498243 
+L 107.518841 118.369496 
+L 112.905304 152.196721 
+L 149.86424 150.171166 
+L 197.383842 127.763469 
+L 194.564179 62.815987 
+z
+" clip-path="url(#p07f458c690)" style="fill: #1f77b4; opacity: 0.3"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 131.8725 112.810932 
+L 131.8725 100.957942 
+L 131.8725 89.104952 
+L 131.8725 77.251961 
+L 131.8725 65.398971 
+L 131.8725 53.545981 
+L 131.8725 41.69299 
+L 131.8725 29.84 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_1">
+      <!-- Monday -->
+      <g transform="translate(112.132656 18.599375) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4d"/>
+       <use xlink:href="#DejaVuSans-6f" x="86.279297"/>
+       <use xlink:href="#DejaVuSans-6e" x="147.460938"/>
+       <use xlink:href="#DejaVuSans-64" x="210.839844"/>
+       <use xlink:href="#DejaVuSans-61" x="274.316406"/>
+       <use xlink:href="#DejaVuSans-79" x="335.595703"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <path d="M 131.8725 112.810932 
+L 122.605459 105.420714 
+L 113.338418 98.030495 
+L 104.071377 90.640277 
+L 94.804336 83.250058 
+L 85.537295 75.859839 
+L 76.270254 68.469621 
+L 67.003213 61.079402 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_2">
+      <!-- Tuesday -->
+      <g transform="translate(35.71226 55.10992) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-75" x="45.958984"/>
+       <use xlink:href="#DejaVuSans-65" x="109.337891"/>
+       <use xlink:href="#DejaVuSans-73" x="170.861328"/>
+       <use xlink:href="#DejaVuSans-64" x="222.960938"/>
+       <use xlink:href="#DejaVuSans-61" x="286.4375"/>
+       <use xlink:href="#DejaVuSans-79" x="347.716797"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <path d="M 131.8725 112.810932 
+L 120.316689 115.448471 
+L 108.760878 118.086009 
+L 97.205067 120.723548 
+L 85.649255 123.361086 
+L 74.093444 125.998625 
+L 62.537633 128.636163 
+L 50.981822 131.273702 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_3">
+      <!-- Wednesday -->
+      <g transform="translate(8.384394 137.14837) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-57"/>
+       <use xlink:href="#DejaVuSans-65" x="93.001953"/>
+       <use xlink:href="#DejaVuSans-64" x="154.525391"/>
+       <use xlink:href="#DejaVuSans-6e" x="218.001953"/>
+       <use xlink:href="#DejaVuSans-65" x="281.380859"/>
+       <use xlink:href="#DejaVuSans-73" x="342.904297"/>
+       <use xlink:href="#DejaVuSans-64" x="395.003906"/>
+       <use xlink:href="#DejaVuSans-61" x="458.480469"/>
+       <use xlink:href="#DejaVuSans-79" x="519.759766"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <path d="M 131.8725 112.810932 
+L 126.72968 123.490108 
+L 121.58686 134.169283 
+L 116.444041 144.848458 
+L 111.301221 155.527634 
+L 106.158401 166.206809 
+L 101.015581 176.885984 
+L 95.872762 187.565159 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_4">
+      <!-- Thursday -->
+      <g transform="translate(66.549171 202.938099) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+       <use xlink:href="#DejaVuSans-75" x="124.462891"/>
+       <use xlink:href="#DejaVuSans-72" x="187.841797"/>
+       <use xlink:href="#DejaVuSans-73" x="228.955078"/>
+       <use xlink:href="#DejaVuSans-64" x="281.054688"/>
+       <use xlink:href="#DejaVuSans-61" x="344.53125"/>
+       <use xlink:href="#DejaVuSans-79" x="405.810547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <path d="M 131.8725 112.810932 
+L 137.01532 123.490108 
+L 142.15814 134.169283 
+L 147.300959 144.848458 
+L 152.443779 155.527634 
+L 157.586599 166.206809 
+L 162.729419 176.885984 
+L 167.872238 187.565159 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_5">
+      <!-- Friday -->
+      <g transform="translate(158.791142 202.938099) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-46" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-46"/>
+       <use xlink:href="#DejaVuSans-72" x="50.269531"/>
+       <use xlink:href="#DejaVuSans-69" x="91.382812"/>
+       <use xlink:href="#DejaVuSans-64" x="119.166016"/>
+       <use xlink:href="#DejaVuSans-61" x="182.642578"/>
+       <use xlink:href="#DejaVuSans-79" x="243.921875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <path d="M 131.8725 112.810932 
+L 143.428311 115.448471 
+L 154.984122 118.086009 
+L 166.539933 120.723548 
+L 178.095745 123.361086 
+L 189.651556 125.998625 
+L 201.207367 128.636163 
+L 212.763178 131.273702 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_6">
+      <!-- Saturday -->
+      <g transform="translate(203.879356 137.14837) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-53"/>
+       <use xlink:href="#DejaVuSans-61" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-74" x="124.755859"/>
+       <use xlink:href="#DejaVuSans-75" x="163.964844"/>
+       <use xlink:href="#DejaVuSans-72" x="227.34375"/>
+       <use xlink:href="#DejaVuSans-64" x="266.707031"/>
+       <use xlink:href="#DejaVuSans-61" x="330.183594"/>
+       <use xlink:href="#DejaVuSans-79" x="391.462891"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <path d="M 131.8725 112.810932 
+L 141.139541 105.420714 
+L 150.406582 98.030495 
+L 159.673623 90.640277 
+L 168.940664 83.250058 
+L 178.207705 75.859839 
+L 187.474746 68.469621 
+L 196.741787 61.079402 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_7">
+      <!-- Sunday -->
+      <g transform="translate(188.978053 55.10992) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use xlink:href="#DejaVuSans-75" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-6e" x="126.855469"/>
+       <use xlink:href="#DejaVuSans-64" x="190.234375"/>
+       <use xlink:href="#DejaVuSans-61" x="253.710938"/>
+       <use xlink:href="#DejaVuSans-79" x="314.990234"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_8">
+      <path d="M 131.8725 100.320953 
+L 122.107441 105.023558 
+L 119.695671 115.590214 
+L 126.453301 124.064015 
+L 137.291699 124.064015 
+L 144.049329 115.590214 
+L 141.637559 105.023558 
+L 131.8725 100.320953 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_8">
+      <!-- 50 -->
+      <g transform="translate(127.092792 99.192009) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <path d="M 131.8725 87.830974 
+L 112.342382 97.236183 
+L 107.518841 118.369496 
+L 121.034102 135.317097 
+L 142.710898 135.317097 
+L 156.226159 118.369496 
+L 151.402618 97.236183 
+L 131.8725 87.830974 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_9">
+      <!-- 100 -->
+      <g transform="translate(122.313084 87.652772) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <path d="M 131.8725 75.340995 
+L 102.577323 89.448808 
+L 95.342012 121.148778 
+L 115.614903 146.57018 
+L 148.130097 146.57018 
+L 168.402988 121.148778 
+L 161.167677 89.448808 
+L 131.8725 75.340995 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_10">
+      <!-- 150 -->
+      <g transform="translate(117.533376 76.113536) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 131.8725 62.851015 
+L 92.812264 81.661434 
+L 83.165182 123.92806 
+L 110.195704 157.823262 
+L 153.549296 157.823262 
+L 180.579818 123.92806 
+L 170.932736 81.661434 
+L 131.8725 62.851015 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_11">
+      <!-- 200 -->
+      <g transform="translate(112.753667 64.5743) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <path d="M 131.8725 50.361036 
+L 83.047205 73.874059 
+L 70.988353 126.707342 
+L 104.776505 169.076345 
+L 158.968495 169.076345 
+L 192.756647 126.707342 
+L 180.697795 73.874059 
+L 131.8725 50.361036 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_12">
+      <!-- 250 -->
+      <g transform="translate(107.973959 53.035064) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_13">
+      <path d="M 131.8725 37.871057 
+L 73.282146 66.086684 
+L 58.811523 129.486624 
+L 99.357307 180.329427 
+L 164.387693 180.329427 
+L 204.933477 129.486624 
+L 190.462854 66.086684 
+L 131.8725 37.871057 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_13">
+      <!-- 300 -->
+      <g transform="translate(103.194251 41.495828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_14">
+    <path d="M 131.8725 88.330573 
+L 107.655154 93.498243 
+L 107.518841 118.369496 
+L 112.905304 152.196721 
+L 149.86424 150.171166 
+L 197.383842 127.763469 
+L 194.564179 62.815987 
+L 131.8725 88.330573 
+" clip-path="url(#p07f458c690)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 131.8725 29.84 
+L 67.003213 61.079402 
+L 50.981822 131.273702 
+L 95.872762 187.565159 
+L 167.872238 187.565159 
+L 212.763178 131.273702 
+L 196.741787 61.079402 
+L 131.8725 29.84 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 378.4725 29.84 
+L 313.603213 61.079402 
+L 297.581822 131.273702 
+L 342.472762 187.565159 
+L 414.472238 187.565159 
+L 459.363178 131.273702 
+L 443.341787 61.079402 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 378.4725 88.330573 
+L 354.255154 93.498243 
+L 354.118841 118.369496 
+L 359.505304 152.196721 
+L 396.46424 150.171166 
+L 443.983842 127.763469 
+L 441.164179 62.815987 
+L 378.4725 88.330573 
+z
+" clip-path="url(#p25da29ea27)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 378.4725 112.810932 
+L 378.4725 100.957942 
+L 378.4725 89.104952 
+L 378.4725 77.251961 
+L 378.4725 65.398971 
+L 378.4725 53.545981 
+L 378.4725 41.69299 
+L 378.4725 29.84 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_14">
+      <!-- Monday -->
+      <g transform="translate(358.732656 18.599375) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-4d"/>
+       <use xlink:href="#DejaVuSans-6f" x="86.279297"/>
+       <use xlink:href="#DejaVuSans-6e" x="147.460938"/>
+       <use xlink:href="#DejaVuSans-64" x="210.839844"/>
+       <use xlink:href="#DejaVuSans-61" x="274.316406"/>
+       <use xlink:href="#DejaVuSans-79" x="335.595703"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_16">
+      <path d="M 378.4725 112.810932 
+L 369.205459 105.420714 
+L 359.938418 98.030495 
+L 350.671377 90.640277 
+L 341.404336 83.250058 
+L 332.137295 75.859839 
+L 322.870254 68.469621 
+L 313.603213 61.079402 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_15">
+      <!-- Tuesday -->
+      <g transform="translate(282.31226 55.10992) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-75" x="45.958984"/>
+       <use xlink:href="#DejaVuSans-65" x="109.337891"/>
+       <use xlink:href="#DejaVuSans-73" x="170.861328"/>
+       <use xlink:href="#DejaVuSans-64" x="222.960938"/>
+       <use xlink:href="#DejaVuSans-61" x="286.4375"/>
+       <use xlink:href="#DejaVuSans-79" x="347.716797"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_17">
+      <path d="M 378.4725 112.810932 
+L 366.916689 115.448471 
+L 355.360878 118.086009 
+L 343.805067 120.723548 
+L 332.249255 123.361086 
+L 320.693444 125.998625 
+L 309.137633 128.636163 
+L 297.581822 131.273702 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_16">
+      <!-- Wednesday -->
+      <g transform="translate(254.984394 137.14837) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-57"/>
+       <use xlink:href="#DejaVuSans-65" x="93.001953"/>
+       <use xlink:href="#DejaVuSans-64" x="154.525391"/>
+       <use xlink:href="#DejaVuSans-6e" x="218.001953"/>
+       <use xlink:href="#DejaVuSans-65" x="281.380859"/>
+       <use xlink:href="#DejaVuSans-73" x="342.904297"/>
+       <use xlink:href="#DejaVuSans-64" x="395.003906"/>
+       <use xlink:href="#DejaVuSans-61" x="458.480469"/>
+       <use xlink:href="#DejaVuSans-79" x="519.759766"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_18">
+      <path d="M 378.4725 112.810932 
+L 373.32968 123.490108 
+L 368.18686 134.169283 
+L 363.044041 144.848458 
+L 357.901221 155.527634 
+L 352.758401 166.206809 
+L 347.615581 176.885984 
+L 342.472762 187.565159 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_17">
+      <!-- Thursday -->
+      <g transform="translate(313.149171 202.938099) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+       <use xlink:href="#DejaVuSans-75" x="124.462891"/>
+       <use xlink:href="#DejaVuSans-72" x="187.841797"/>
+       <use xlink:href="#DejaVuSans-73" x="228.955078"/>
+       <use xlink:href="#DejaVuSans-64" x="281.054688"/>
+       <use xlink:href="#DejaVuSans-61" x="344.53125"/>
+       <use xlink:href="#DejaVuSans-79" x="405.810547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_19">
+      <path d="M 378.4725 112.810932 
+L 383.61532 123.490108 
+L 388.75814 134.169283 
+L 393.900959 144.848458 
+L 399.043779 155.527634 
+L 404.186599 166.206809 
+L 409.329419 176.885984 
+L 414.472238 187.565159 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_18">
+      <!-- Friday -->
+      <g transform="translate(405.391142 202.938099) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-46"/>
+       <use xlink:href="#DejaVuSans-72" x="50.269531"/>
+       <use xlink:href="#DejaVuSans-69" x="91.382812"/>
+       <use xlink:href="#DejaVuSans-64" x="119.166016"/>
+       <use xlink:href="#DejaVuSans-61" x="182.642578"/>
+       <use xlink:href="#DejaVuSans-79" x="243.921875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_20">
+      <path d="M 378.4725 112.810932 
+L 390.028311 115.448471 
+L 401.584122 118.086009 
+L 413.139933 120.723548 
+L 424.695745 123.361086 
+L 436.251556 125.998625 
+L 447.807367 128.636163 
+L 459.363178 131.273702 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_19">
+      <!-- Saturday -->
+      <g transform="translate(450.479356 137.14837) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use xlink:href="#DejaVuSans-61" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-74" x="124.755859"/>
+       <use xlink:href="#DejaVuSans-75" x="163.964844"/>
+       <use xlink:href="#DejaVuSans-72" x="227.34375"/>
+       <use xlink:href="#DejaVuSans-64" x="266.707031"/>
+       <use xlink:href="#DejaVuSans-61" x="330.183594"/>
+       <use xlink:href="#DejaVuSans-79" x="391.462891"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_21">
+      <path d="M 378.4725 112.810932 
+L 387.739541 105.420714 
+L 397.006582 98.030495 
+L 406.273623 90.640277 
+L 415.540664 83.250058 
+L 424.807705 75.859839 
+L 434.074746 68.469621 
+L 443.341787 61.079402 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_20">
+      <!-- Sunday -->
+      <g transform="translate(435.578053 55.10992) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-53"/>
+       <use xlink:href="#DejaVuSans-75" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-6e" x="126.855469"/>
+       <use xlink:href="#DejaVuSans-64" x="190.234375"/>
+       <use xlink:href="#DejaVuSans-61" x="253.710938"/>
+       <use xlink:href="#DejaVuSans-79" x="314.990234"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 378.4725 100.320953 
+L 368.707441 105.023558 
+L 366.295671 115.590214 
+L 373.053301 124.064015 
+L 383.891699 124.064015 
+L 390.649329 115.590214 
+L 388.237559 105.023558 
+L 378.4725 100.320953 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_21">
+      <!-- 50 -->
+      <g transform="translate(373.692792 99.192009) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_23">
+      <path d="M 378.4725 87.830974 
+L 358.942382 97.236183 
+L 354.118841 118.369496 
+L 367.634102 135.317097 
+L 389.310898 135.317097 
+L 402.826159 118.369496 
+L 398.002618 97.236183 
+L 378.4725 87.830974 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_22">
+      <!-- 100 -->
+      <g transform="translate(368.913084 87.652772) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_24">
+      <path d="M 378.4725 75.340995 
+L 349.177323 89.448808 
+L 341.942012 121.148778 
+L 362.214903 146.57018 
+L 394.730097 146.57018 
+L 415.002988 121.148778 
+L 407.767677 89.448808 
+L 378.4725 75.340995 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_23">
+      <!-- 150 -->
+      <g transform="translate(364.133376 76.113536) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_25">
+      <path d="M 378.4725 62.851015 
+L 339.412264 81.661434 
+L 329.765182 123.92806 
+L 356.795704 157.823262 
+L 400.149296 157.823262 
+L 427.179818 123.92806 
+L 417.532736 81.661434 
+L 378.4725 62.851015 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_24">
+      <!-- 200 -->
+      <g transform="translate(359.353667 64.5743) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_26">
+      <path d="M 378.4725 50.361036 
+L 329.647205 73.874059 
+L 317.588353 126.707342 
+L 351.376505 169.076345 
+L 405.568495 169.076345 
+L 439.356647 126.707342 
+L 427.297795 73.874059 
+L 378.4725 50.361036 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_25">
+      <!-- 250 -->
+      <g transform="translate(354.573959 53.035064) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_27">
+      <path d="M 378.4725 37.871057 
+L 319.882146 66.086684 
+L 305.411523 129.486624 
+L 345.957307 180.329427 
+L 410.987693 180.329427 
+L 451.533477 129.486624 
+L 437.062854 66.086684 
+L 378.4725 37.871057 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="text_26">
+      <!-- 300 -->
+      <g transform="translate(349.794251 41.495828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_28">
+    <path d="M 378.4725 88.330573 
+L 354.255154 93.498243 
+L 354.118841 118.369496 
+L 359.505304 152.196721 
+L 396.46424 150.171166 
+L 443.983842 127.763469 
+L 441.164179 62.815987 
+L 378.4725 88.330573 
+" clip-path="url(#p25da29ea27)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 378.4725 29.84 
+L 313.603213 61.079402 
+L 297.581822 131.273702 
+L 342.472762 187.565159 
+L 414.472238 187.565159 
+L 459.363178 131.273702 
+L 443.341787 61.079402 
+L 378.4725 29.84 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p07f458c690">
+   <path d="M 131.8725 29.84 
+L 67.003213 61.079402 
+L 50.981822 131.273702 
+L 95.872762 187.565159 
+L 167.872238 187.565159 
+L 212.763178 131.273702 
+L 196.741787 61.079402 
+z
+"/>
+  </clipPath>
+  <clipPath id="p25da29ea27">
+   <path d="M 378.4725 29.84 
+L 313.603213 61.079402 
+L 297.581822 131.273702 
+L 342.472762 187.565159 
+L 414.472238 187.565159 
+L 459.363178 131.273702 
+L 443.341787 61.079402 
+z
+"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
Introduces a [radar chart](https://en.wikipedia.org/wiki/Radar_chart) (also called spider or start chart) to visualize the message frequency per day of the week. Leverages a blueprint from the Matplotlib docs [nice tutorial](https://matplotlib.org/stable/gallery/specialty_plots/radar_chart.html) that already holds everything we need.
Closes #59.