### PR TITLE
Enable check for radar projection registration to circumvent error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ ax = vis.wordcloud(parser.df, ax=ax, stopwords=stopwords, **kwargs)
 
 ### 4.4 Radarchart: Message count per weekday
 ```python
+if not vis.is_radar_registered():
+	vis.radar_factory(7, frame="polygon")
 fig, ax = plt.subplots(1, 2, figsize=(7, 3), subplot_kw={'projection': 'radar'})
 ax[0] = vis.radar(parser.df, ax=ax[0])
 ax[1] = vis.radar(parser.df, ax=ax[1], color='C1', alpha=0)

--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -3,7 +3,6 @@ import datetime
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from pandas.api.types import CategoricalDtype
 from wordcloud import WordCloud, STOPWORDS
 from dateutil.relativedelta import relativedelta
 from matplotlib.patches import Polygon
@@ -26,7 +25,7 @@ def sunburst(
     isolines=None,
     isolines_relative=True,
     ax=None,
-    authors=[],
+    authors=None,
 ):
     if authors:
         df = df[df["author"].isin(authors)]
@@ -98,7 +97,7 @@ def sunburst(
     return ax
 
 
-def wordcloud(df, ax=None, stopwords=None, authors=[], **kwargs):
+def wordcloud(df, ax=None, stopwords=None, authors=None, **kwargs):
     if authors:
         df = df[df["author"].isin(authors)]
 
@@ -139,7 +138,7 @@ def calendar_heatmap(
     monthticks=True,
     monthly_border=False,
     ax=None,
-    authors=[],
+    authors=None,
     **kwargs,
 ):
     """
@@ -269,7 +268,7 @@ def radar(
     color="C0",
     alpha=0.3,
     ax=None,
-    authors=[],
+    authors=None,
 ):
     if authors:
         df = df[df["author"].isin(authors)]

--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -375,3 +375,11 @@ def radar_factory(num_vars, frame="circle"):
 
     register_projection(RadarAxes)
     return theta
+
+
+def is_radar_registered():
+    try:
+        plt.subplots(subplot_kw={"projection": "radar"})
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
- Introduces check for existence of radar projection in local matplotlib config `via is_radar_registered()`
- Added hint to README to register radar projection in case it's not available yet

Fixes #69, Fixes #74