### PR TITLE
Made regex for WhatsApp date format more restrictive

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -120,7 +120,7 @@ class WhatsAppParser(Parser):
 
     def _read_file_into_list(self):
         def _is_new_message(line):
-            regex = r"(^[\u200e]?\[?((\d{1})|(\d{2})|(\d{4}))((\.)|(\/)|(\-))((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{4})|(\d{2})))"
+            regex = r"^[\u200e]?\[?((\d{1})|(\d{2})|(\d{4}))((\.)|(\/)|(\-))((\d{1})|(\d{2}))((\.)|(\/)|(\-))((\d{4})|(\d{2}))((\,)|(\ ))"
             return re.match(regex, line)
 
         self._logger.info("Starting reading raw messages into memory...")


### PR DESCRIPTION
WhatsApp date format has now an additional check for either comma or space in the end: `((\,)|(\ ))`.
This makes the regex more restrictive and fixes #72.