### PR TITLE
Throw explicit error if no messages in filtered year for heatmap

### DIFF
--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -149,6 +149,12 @@ def calendar_heatmap(
     if authors:
         df = df[df["author"].isin(authors)]
 
+    if not year in df["datetime"].dt.year.values:
+        available_years = df["datetime"].dt.year.unique()
+        raise ValueError(
+            f"No message in year {year}. Available years: {available_years}"
+        )
+
     df = df[df["datetime"].dt.year == year]
     df = df.groupby(by=df["datetime"].dt.date).count()["message"].reset_index()
 


### PR DESCRIPTION
This PR introduces an explicit error if the dataframe would be empty after filtering on the year.
Before, we did not catch this case. An error (`ValueError: cannot convert float NaN to integer`) was only thrown when setting the colorbar.