### PR TITLE
Add typing

### DIFF
--- a/chatminer/chatparsers.py
+++ b/chatminer/chatparsers.py
@@ -387,7 +387,5 @@ class WhatsAppDateFormat:
             date1 = "month"
             date2 = "day"
             date3 = "year"
-        self._logger.info(
-            "Inferred date format: %s%s%s%s%s%s%s",
-            (start, date1, self.date_sep, date2, self.date_sep, date3, end),
-        )
+        composition = f"{start}{date1}{self.date_sep}{date2}{self.date_sep}{date3}{end}"
+        self._logger.info("Inferred date format: %s", composition)

--- a/chatminer/nlp.py
+++ b/chatminer/nlp.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pandas as pd
 from transformers import pipeline
 
@@ -24,7 +26,7 @@ def add_sentiment(df: pd.DataFrame, lang: str = "en") -> pd.DataFrame:
     )
     sentiment_pipeline = pipeline("sentiment-analysis", model=model_path)
 
-    def extract_sentiment(message: str) -> str | None:
+    def extract_sentiment(message: str) -> Optional[str]:
         """
         Extract sentiment from message
 

--- a/chatminer/nlp.py
+++ b/chatminer/nlp.py
@@ -24,7 +24,7 @@ def add_sentiment(df: pd.DataFrame, lang: str = "en") -> pd.DataFrame:
     )
     sentiment_pipeline = pipeline("sentiment-analysis", model=model_path)
 
-    def extract_sentiment(message: str) -> str:
+    def extract_sentiment(message: str) -> str | None:
         """
         Extract sentiment from message
 
@@ -36,7 +36,7 @@ def add_sentiment(df: pd.DataFrame, lang: str = "en") -> pd.DataFrame:
 
         """
         try:
-            return sentiment_pipeline(message)[0]["label"]
+            return str(sentiment_pipeline(message)[0]["label"])
         except:
             print(f"Error processing message: {message}")
             return None


### PR DESCRIPTION
This isn't 100% typed because the libraries that we depend on aren't 100% typed so I had to guess for some things. This caused me to find issue #97 (which you should check out). Apart from typing this PR:

- Standardizes default/failure values to `None` instead of some of them being `False`
- Uses `dt` instead of `datetime` in order to explicitly define timestamp as `dt.datetime` instead of making the type-hint the module, which was incorrect
- Changes abstract methods from simply returning to having `...`
- Wraps `mess["timestamp_ms"]` in `int()` to explicitly show that it is an int (helpful for type-checking)
- Adds a few assert statements that make type-checking work
- Changes all formatted strings to f-strings (to please pylint)