### PR TITLE
fix missing name parameter in calendar_heatmap

### DIFF
--- a/chatminer/visualizations.py
+++ b/chatminer/visualizations.py
@@ -181,7 +181,7 @@ def calendar_heatmap(
     )
 
     df_joined = (
-        df_calendar.to_frame()
+        df_calendar.to_frame(name="date")
         .join(df_day, on="date", how="left")
         .fill_null(strategy="zero")
     )


### PR DESCRIPTION
When calling calendar_heatmap I got an error that this line:
https://github.com/joweich/chat-miner/blob/b7d0ea64f79677eea3fbcfb783a54b24c1a35949/chatminer/visualizations.py#L185
failed. This PR fixes this issue by manually setting the novel dataframe's columnname to "date" (previously it was "literal" for some reason.